### PR TITLE
Fix IndexError when filling layouts

### DIFF
--- a/wot/scripts/base/Requests/AccountRequests.py
+++ b/wot/scripts/base/Requests/AccountRequests.py
@@ -367,7 +367,8 @@ def setAndFillLayouts(proxy, requestID, *args):
 		
 		shellsCDs = [shells[i] for i in range(0, len(shells), 2)]
 		shellsCounts = [shells[i+1] for i in range(0, len(shells), 2)]
-		prevShellsCounts = [i_data['inventory'][1]['shells'][vehInvID][i+1] for i in range(0, len(shells), 2)]
+                prevShells = i_data['inventory'][1]['shells'].get(vehInvID, [])
+                prevShellsCounts = [prevShells[i + 1] if i + 1 < len(prevShells) else 0 for i in range(0, len(shells), 2)]
 		
 		eqsCDs = [eqsList[i] for i in range(0, len(eqsList), 2)]
 		prevEqs = i_data['inventory'][1]['eqs'][vehInvID]


### PR DESCRIPTION
## Summary
- guard against varying length shell layouts when handling `CMD_SET_AND_FILL_LAYOUTS`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b7a38498832fb7bf708feeb7ef6b